### PR TITLE
chore: add .gitignore and .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+PORT=port-number
+
+MONGODB_URI="mongodb-uri"
+
+
+ACCESS_TOKEN="access_token"
+
+
+NODE_ENV="development"

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,14 @@
+# Dependencies
+node_modules/
+
+# Environment varibales
+.env
+
+.env*
+
+!.env*.example
+
+dist/
+logs/
+*.log
+.DS_Store


### PR DESCRIPTION
Added a .gitignore to exclude node_modules, .env, and other common local/dev files.

Added .env.example to provide a template for required environment variables without exposing secrets.